### PR TITLE
Fixes bug for empty api token exception

### DIFF
--- a/src/Error/Required.php
+++ b/src/Error/Required.php
@@ -26,7 +26,12 @@ namespace Paynl\Error;
  */
 class Required extends \Exception
 {
-    public function __construct($message, $code, Exception $previous)
+    /***
+     * @param string          $message
+     * @param null            $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($message, $code = null, \Exception $previous = null)
     {
         $message = "'$message' is required";
         parent::__construct($message, $code, $previous);


### PR DESCRIPTION
Missing argument 2 for Paynl\Error\Required::__construct(), called in
/src/Error/Required/ApiToken.php on line 33
